### PR TITLE
Firefox 35 compatibility: "let foo" should precede function calls that use foo

### DIFF
--- a/lib/browserAction.js
+++ b/lib/browserAction.js
@@ -112,6 +112,7 @@ function initializePopup(browserAction, badgeState) {
     let contentScriptOptions = {
         channelName: 'browserAction'
     };
+    let widgetViews = [];
     // Create and expose message passing API
     let channel = createMessageChannel(contentScriptOptions);
     browserAction.onMessage = channel.onMessage;
@@ -130,7 +131,6 @@ function initializePopup(browserAction, badgeState) {
     });
     setPanelPlaceholder();
 
-    let widgetViews = [];
     var returnValue = {
         destroy: destroy,
         registerWidgetView: registerWidgetView


### PR DESCRIPTION
Firefox 35 implements ES6's "temporal dead zone" making it invalid to access a
let variable before its initialization. Hence "let foo" shoulde precede any
calls to inner functions that use "foo".

Without the fix the module fails under Firefox 35 with the error:
ReferenceError: can't access let declaration `widgetViews' before initialization

The fix is trivial, just move "let widgetViews" a bit higher up (before the setPanelPlaceholder call).