### PR TITLE
make messageID from sendMessage() 100% unique per thread

### DIFF
--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -61,7 +61,7 @@ function createMessageChannel(options, port) {
     const channelSuffix = CONTEXT == 'content script' ? ''+Math.random() : '';
     // Generate random identifier to track the path of a message during the routing
     const THIS_CHANNEL_ID = Math.random();
-    
+
     var setTimeout = typeof window == 'undefined' ? require('sdk/timers').setTimeout : window.setTimeout;
     const throw_async = function(e) setTimeout(function() { throw e; }, 0);
 
@@ -117,13 +117,13 @@ function createMessageChannel(options, port) {
         if (!path) return;
         response = JSON_stringify(response);
         delete packagePaths[sendResponseID];
-        var packet = { 
-            path: path, 
+        var packet = {
+            path: path,
             direction:  CONTEXT == 'main' ? 'down' : 'up',
             isResponse: true,
             messageID: sendResponseID,
             message: response
-        };  
+        };
         deliverPacket(packet);
     }
 
@@ -144,7 +144,7 @@ function createMessageChannel(options, port) {
         onMessage: onMessage
     };
 
-    var response_callbacks = [];
+    var response_callbacks = [], _unique_id_ = 0;
     function sendMessage(message, callback) {
         if (callback && typeof callback != 'function')
             throw new Error('Usage: extension.sendMessage(any message, function callback)');
@@ -152,7 +152,7 @@ function createMessageChannel(options, port) {
         var messageID;
         message = JSON_stringify(message);
         if (callback) {
-            messageID = Math.random();
+            messageID = (++_unique_id_)+(Math.random()+'').substr(1);
             response_callbacks[messageID] = callback;
         }
 
@@ -247,7 +247,7 @@ function createMessageChannel(options, port) {
 
     if (endAtPage && CONTEXT == 'content script') {
         // Set up API for page
-        document.documentElement.setAttribute('onreset', 
+        document.documentElement.setAttribute('onreset',
             'document.documentElement.removeAttribute("onreset");' +
             '(' + createMessageChannel + ')(' + JSON.stringify({channelName: channelName + channelSuffix}) + ');'
         );
@@ -256,6 +256,6 @@ function createMessageChannel(options, port) {
     if (isAtBottomOfChannel) {
         window.extension = extension; // Export to global scope
     }
-    
+
     return extension;
 }


### PR DESCRIPTION
I know the chances two different messages will have same ID using `messageID = Math.random()` are close to 0%, but as the application runs and there are more and more messages, the collision probability increases.

I added a counter variable `_unique_id_` to make sure `messageID` is unique per thread/module. The random part make it unique at Add-on level.

P.S. Sorry for extra lines touched, my editor removes trailing white spaces.
